### PR TITLE
Remove media properties and let provide them by users without predefined values

### DIFF
--- a/src/components/IpfsAudio.tsx
+++ b/src/components/IpfsAudio.tsx
@@ -1,33 +1,18 @@
-import React from 'react';
-import { HTMLAttributes, FC } from 'react';
+import React, { FC, MediaHTMLAttributes } from 'react';
 import { cleanUpHash, DEFAULT_IPFS_GATEWAY_URL } from '../utils';
 
-export interface IIpfsAudioProps extends HTMLAttributes<HTMLVideoElement> {
+export interface IIpfsAudioProps extends MediaHTMLAttributes<HTMLVideoElement> {
   hash: string;
   gatewayUrl?: string;
-  autoPlay?: boolean;
-  muted?: boolean;
-  loop?: boolean;
-  controls?: boolean;
 }
 
 export const IpfsAudio: FC<IIpfsAudioProps> = ({
   hash,
   gatewayUrl = DEFAULT_IPFS_GATEWAY_URL,
-  autoPlay = true,
-  muted = false,
-  controls = true,
-  loop = false,
   ...props
 }) => {
   return (
-    <audio
-      loop={loop}
-      autoPlay={autoPlay}
-      muted={muted}
-      controls={controls}
-      {...props}
-    >
+    <audio {...props}>
       <source src={`${gatewayUrl}/${cleanUpHash(hash)}`} />
     </audio>
   );

--- a/src/components/IpfsAudio.tsx
+++ b/src/components/IpfsAudio.tsx
@@ -21,7 +21,13 @@ export const IpfsAudio: FC<IIpfsAudioProps> = ({
   ...props
 }) => {
   return (
-    <audio loop autoPlay muted controls {...props}>
+    <audio
+      loop={loop}
+      autoPlay={autoPlay}
+      muted={muted}
+      controls={controls}
+      {...props}
+    >
       <source src={`${gatewayUrl}/${cleanUpHash(hash)}`} />
     </audio>
   );

--- a/src/components/IpfsImage.tsx
+++ b/src/components/IpfsImage.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { HTMLAttributes, FC } from 'react';
+import React, { HTMLAttributes, FC } from 'react';
 import { cleanUpHash, DEFAULT_IPFS_GATEWAY_URL } from '../utils';
 
 export interface IIpfsImageProps extends HTMLAttributes<HTMLImageElement> {

--- a/src/components/IpfsMedia.tsx
+++ b/src/components/IpfsMedia.tsx
@@ -8,10 +8,6 @@ export type IIpfsMediaProps = IIpfsVideoProps & IIpfsImageProps;
 export const IpfsMedia: FC<IIpfsMediaProps> = ({
   hash,
   gatewayUrl,
-  autoPlay = true,
-  muted = true,
-  controls = true,
-  loop = true,
   ...props
 }) => {
   const [imgError, setImgError] = useState(false);
@@ -28,15 +24,7 @@ export const IpfsMedia: FC<IIpfsMediaProps> = ({
         <IpfsImage hash={hash} onError={() => setImgError(true)} {...props} />
       )}
       {!vidError && (
-        <IpfsVideo
-          hash={hash}
-          onError={() => setVidError(true)}
-          autoPlay={autoPlay}
-          muted={muted}
-          controls={controls}
-          loop={loop}
-          {...props}
-        />
+        <IpfsVideo hash={hash} onError={() => setVidError(true)} {...props} />
       )}
     </>
   );

--- a/src/components/IpfsVideo.tsx
+++ b/src/components/IpfsVideo.tsx
@@ -21,7 +21,13 @@ export const IpfsVideo: FC<IIpfsVideoProps> = ({
   ...props
 }) => {
   return (
-    <video loop autoPlay muted controls {...props}>
+    <video
+      loop={loop}
+      autoPlay={autoPlay}
+      muted={muted}
+      controls={controls}
+      {...props}
+    >
       <source src={`${gatewayUrl}/${cleanUpHash(hash)}`} />
     </video>
   );

--- a/src/components/IpfsVideo.tsx
+++ b/src/components/IpfsVideo.tsx
@@ -1,33 +1,18 @@
-import React from 'react';
-import { HTMLAttributes, FC } from 'react';
+import React, { FC, MediaHTMLAttributes } from 'react';
 import { cleanUpHash, DEFAULT_IPFS_GATEWAY_URL } from '../utils';
 
-export interface IIpfsVideoProps extends HTMLAttributes<HTMLVideoElement> {
+export interface IIpfsVideoProps extends MediaHTMLAttributes<HTMLVideoElement> {
   hash: string;
   gatewayUrl?: string;
-  autoPlay?: boolean;
-  muted?: boolean;
-  loop?: boolean;
-  controls?: boolean;
 }
 
 export const IpfsVideo: FC<IIpfsVideoProps> = ({
   hash,
   gatewayUrl = DEFAULT_IPFS_GATEWAY_URL,
-  autoPlay = true,
-  muted = true,
-  controls = true,
-  loop = true,
   ...props
 }) => {
   return (
-    <video
-      loop={loop}
-      autoPlay={autoPlay}
-      muted={muted}
-      controls={controls}
-      {...props}
-    >
+    <video {...props}>
       <source src={`${gatewayUrl}/${cleanUpHash(hash)}`} />
     </video>
   );


### PR DESCRIPTION
I came across that no matter if I add media properties to the component, it renders with predefined values. Removed them to provide native-like experience.
